### PR TITLE
Remove redundant `[profile.release]` lines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,3 @@ codegen-units = 1
 # Do a second optimization pass over the entire program, including dependencies.
 # Slows compile times, marginal improvements.
 lto = "thin"
-# Optimize with performance in mind.
-opt-level = 3
-# Keep debug information in the binary.
-strip = "none"


### PR DESCRIPTION
These are `release` profile defaults, so no need to specify them.