### PR TITLE
Cargo generate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bevy_scaffold"
+name = "{{ crate_name }}"
 version = "0.1.0"
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "{{ crate_name }}"
+name = "{{project-name}}"
 version = "0.1.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ bevy new projectname
 Using [`cargo generate`](https://cargo-generate.github.io/cargo-generate/):
 ```shell
 cargo install cargo-generate
-cargo generate projectname --git https://github.com/thebevyflock/bevy_new
+cargo generate thebevyflock/bevy_new
 ```
 
 ## License

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,7 +1,6 @@
 [template]
 cargo_generate_version = "0.21.3"
 ignore = [
-    ".github/workflows/ci-generate.yaml",
     "LICENSE-Apache-2.0.txt",
     "LICENSE-CC0-1.0.txt",
     "LICENSE-MIT.txt",

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -6,7 +6,6 @@ ignore = [
     "LICENSE-CC0-1.0.txt",
     "LICENSE-MIT.txt",
     "README.md",
-    "cargo-generate.toml",
     "scripts",
 ]
 

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,11 +1,10 @@
 [template]
-cargo_generate_version = "0.21.3"
+cargo_generate_version = "0.22"
 ignore = [
     "LICENSE-Apache-2.0.txt",
     "LICENSE-CC0-1.0.txt",
     "LICENSE-MIT.txt",
     "README.md",
-    "scripts",
 ]
 
 

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,10 +1,13 @@
 [template]
 cargo_generate_version = "0.21.3"
 ignore = [
+    ".github/workflows/ci-generate.yaml",
     "LICENSE-Apache-2.0.txt",
     "LICENSE-CC0-1.0.txt",
     "LICENSE-MIT.txt",
     "README.md",
+    "cargo-generate.toml",
+    "scripts",
 ]
 
 

--- a/scripts/post-generation.rhai
+++ b/scripts/post-generation.rhai
@@ -1,2 +1,3 @@
 // Actions to take following template generation.
 system::command("cargo", ["update"]);
+file::delete("scripts");

--- a/scripts/post-generation.rhai
+++ b/scripts/post-generation.rhai
@@ -1,4 +1,2 @@
 // Actions to take following template generation.
 system::command("cargo", ["update"]);
-file::delete("scripts");
-file::delete("cargo-generate.toml");


### PR DESCRIPTION
This:
- [x] correctly ignores template files the user won't need
- [x] stops deleting files in the post-install hook
- [x] uses `crate_name` built-in placeholder

Regarding "allows setting project name": I think this responsibility probably belongs with cargo generate (or at least the CLI's wrapped version of it) since it already provides a good mechanism for setting and reading the name.