### PR TITLE
remove unused lockfile command 

### DIFF
--- a/post-generate.rhai
+++ b/post-generate.rhai
@@ -1,5 +1,2 @@
 // Rename template files.
 file::rename("Cargo.toml.template", "Cargo.toml");
-
-// Generate `Cargo.lock`.
-system::command("cargo", ["update", "--package", variable::get("project-name")]);


### PR DESCRIPTION
Currently when running `bevy new` to generate a new project with this template, the user is prompted to run a script.

![image](https://github.com/user-attachments/assets/3912e913-57a4-4df7-978b-4c7f7d42ccca)

The lockfile update script was [initially added](https://discord.com/channels/691052431525675048/1278871953721262090/1331856682510454784) as a way to make it so that users could generate a new bevy_new_2d project, immediately commit after generating, and have the github workflows work. (The workflows are written to require --locked in that template).

This script is neither explained to the user nor required for the current functionality in this template so this PR removes the unused lockfile command so that it doesn't prompt the user to run it every time a new template is created.