### PR TITLE
Bump cargo generate to 23

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = "0.22"
+cargo_generate_version = "0.23"
 include = ["*.template"]
 ignore = [
     ".github/workflows/ci-generate.yaml",


### PR DESCRIPTION
tested with:

```
❯ cargo-generate generate -g https://github.com/DaAlbrecht/bevy_new_minimal --branch bump-cargo-generate
❯ head -n 3 Cargo.toml
[package]
name = "foo"
version = "0.2.0"
```

Why did we update in https://github.com/TheBevyFlock/bevy_new_minimal/pull/15 the version in `Cargo.toml` from `0.1.0` to `0.2.0`?