### PR TITLE
Return `AppExit`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
 
-fn main() {
-    App::new().add_plugins(DefaultPlugins).run();
+fn main() -> AppExit {
+    App::new().add_plugins(DefaultPlugins).run()
 }


### PR DESCRIPTION
Makes the main function return `AppExit` to be consistent with `bevy_new_2d` and to not trigger the `main_return_without_appexit` bevy lint.