### PR TITLE
Revert to v0.1.0 and update to Rust 2024

### DIFF
--- a/.github/workflows/ci-generate.yaml
+++ b/.github/workflows/ci-generate.yaml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   pull_request:
-     branches:
-       - main
+    branches:
+      - main
 
 jobs:
   # Compare committed files with those generated from templates to ensure no differences occur.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_new_minimal"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 bevy = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_new_minimal"
-version = "0.2.0"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml.template
+++ b/Cargo.toml.template
@@ -1,7 +1,7 @@
 [package]
 name = "{{project-name}}"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 bevy = "0.15"

--- a/Cargo.toml.template
+++ b/Cargo.toml.template
@@ -1,6 +1,6 @@
 [package]
 name = "{{project-name}}"
-version = "0.2.0"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
I plan on creating a `bevy-0.15` tag after this PR and before https://github.com/TheBevyFlock/bevy_new_minimal/pull/17.